### PR TITLE
DB Resolver: set primary name

### DIFF
--- a/packages/contracts/script/local/DatabaseResolver.s.sol
+++ b/packages/contracts/script/local/DatabaseResolver.s.sol
@@ -3,9 +3,6 @@ pragma solidity ^0.8.13;
 
 import {Script, console} from "forge-std/Script.sol";
 import {ENSRegistry} from "@ens-contracts/registry/ENSRegistry.sol";
-import {ReverseRegistrar} from
-    "@ens-contracts/reverseRegistrar/ReverseRegistrar.sol";
-import {UniversalResolver} from "@ens-contracts/utils/UniversalResolver.sol";
 
 import {ENSHelper} from "../Helper.sol";
 import {DatabaseConfig} from "../config/DatabaseConfig.s.sol";

--- a/packages/contracts/src/DatabaseResolver.sol
+++ b/packages/contracts/src/DatabaseResolver.sol
@@ -170,6 +170,12 @@ contract DatabaseResolver is
         override
         returns (bytes memory)
     {
+        if (bytes4(data[:4]) == this.name.selector) {
+            // name(bytes32) should be handled on-chain
+            (, bytes memory result) = address(this).staticcall(data);
+            return result;
+        }
+
         _offChainLookup(data);
     }
 


### PR DESCRIPTION
# DB Resolver: set primary name

## All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

## Description

The flow of fetching the primary name involves calling the Universal Resolver which relies on the `resolver(node, encodedFunc)` function of the domain's resolver.

The current implementation was causing the `resolve` with `name(bytes32)` function encoded as an argument to revert as an `OffchainLookup` which is supported by the `Universal Resolver`. However, since the `setName` cannot be handled off-chain because the ENS contracts don't support the EIP-5559 yet, we had to implement both the `setName` and `name` function on-chain. Therefore, we should not revert with `OffchainLookup`. 

## Related Issue

#149 

## Changes
- [ ] New feature implementation
- [X] Bug fix
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Other (please specify)

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

## Additional Notes
<!--- (Add any additional information or context relevant to the pull request.) -->
