### PR TITLE
feat: support multicall on getOperationHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project not only makes ENS more efficient and cost-effective but also opens
 | --------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | DatabaseResolver            | Ethereum | [0xEB3e3a9f737f7bEED451a0f8A41033082abC9B6b](https://sepolia.etherscan.io/address/0xEB3e3a9f737f7bEED451a0f8A41033082abC9B6b) |
 | ArbitrumVerifier            | Ethereum | [0x8fc4a214705e3c40032e99f867d964c012bf8efb](https://sepolia.etherscan.io/address/0x8fc4a214705e3c40032e99f867d964c012bf8efb) |
-| L1Resolver                  | Ethereum | [0x32D18361Acc3f3058565AAFD3F27Fe3d5135b4aD](https://sepolia.etherscan.io/address/0x32D18361Acc3f3058565AAFD3F27Fe3d5135b4aD) |
+| L1Resolver                  | Ethereum | [0x4271062783992cF019B353EAe923780a02E88E10](https://sepolia.etherscan.io/address/0x4271062783992cF019B353EAe923780a02E88E10) |
 | ENSRegistry                 | Arbitrum | [0x8d55e297c37993ebbd2e7a8d7688f7e5b35f1b50](https://sepolia.arbiscan.io/address/0x8d55e297c37993ebbd2e7a8d7688f7e5b35f1b50)  |
 | ReverseRegistrar            | Arbitrum | [0xb3c9ff08671bbadddd0436cc46fbfa005c8da0a7](https://sepolia.arbiscan.io/address/0xb3c9ff08671bbadddd0436cc46fbfa005c8da0a7)  |
 | BaseRegistrarImplementation | Arbitrum | [0x2C6a113C513fa0fd404abcCE3aC8a4BE16ccb651](https://sepolia.arbiscan.io/address/0x2C6a113C513fa0fd404abcCE3aC8a4BE16ccb651)  |

--- a/packages/contracts/src/L1Resolver.sol
+++ b/packages/contracts/src/L1Resolver.sol
@@ -129,6 +129,8 @@ contract L1Resolver is
                 || selector == TextResolver.setText.selector
                 || selector == ContentHashResolver.setContenthash.selector
                 || selector == NameResolver.setName.selector
+                || selector == IMulticallable.multicall.selector
+                || selector == IMulticallable.multicallWithNodeCheck.selector
         ) _offChainStorage(targets[TARGET_RESOLVER]);
 
         revert FunctionNotSupported();


### PR DESCRIPTION
# support multicall on getOperationHandler

## All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

## Description

Support `multicall` and `multicallWithNodeCheck` on the `getOperationHandler` redirecting the request to the `resolver`.

This change aims to support multiple records setting through a single transaction.